### PR TITLE
Remove undo/redo command capabilities due to security issues

### DIFF
--- a/docs/team/JeremyYirenLow_PPP.adoc
+++ b/docs/team/JeremyYirenLow_PPP.adoc
@@ -1,6 +1,6 @@
 = Jeremy Low - Portfolio for *_PDF++_*
 :plus: &#43;
-:imagesDir: images
+:imagesDir: ../images
 ifdef::env-github[]
 :tip-caption: :bulb:
 :note-caption: :information_source:

--- a/src/main/java/seedu/address/logic/CommandHistory.java
+++ b/src/main/java/seedu/address/logic/CommandHistory.java
@@ -34,6 +34,13 @@ public class CommandHistory {
         return unmodifiableUserInputHistory;
     }
 
+    /**
+     * Returns the last command entered {@code userInputHistory}.
+     */
+    public String getLastCommand() {
+        return unmodifiableUserInputHistory.get(unmodifiableUserInputHistory.size());
+    }
+
     @Override
     public boolean equals(Object obj) {
         // short circuit if same object

--- a/src/main/java/seedu/address/logic/parser/PdfBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/PdfBookParser.java
@@ -105,9 +105,6 @@ public class PdfBookParser {
         case OpenCommand.COMMAND_WORD:
             return new OpenCommandParser().parse(arguments);
 
-        case RedoCommand.COMMAND_WORD:
-            return new RedoCommand();
-
         case SelectCommand.COMMAND_WORD:
             return new SelectCommandParser().parse(arguments);
 
@@ -116,9 +113,13 @@ public class PdfBookParser {
 
         case TagCommand.COMMAND_WORD:
             return new TagCommandParser().parse(arguments);
-
+        /*
         case UndoCommand.COMMAND_WORD:
             return new UndoCommand();
+
+        case RedoCommand.COMMAND_WORD:
+            return new RedoCommand();
+         */
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/PdfBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/PdfBookParser.java
@@ -23,11 +23,11 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.MergeCommand;
 import seedu.address.logic.commands.MoveCommand;
 import seedu.address.logic.commands.OpenCommand;
-import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.commands.TagCommand;
-import seedu.address.logic.commands.UndoCommand;
+//import seedu.address.logic.commands.UndoCommand;
+//import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -16,6 +16,7 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 
+import seedu.address.logic.CommandHistory;
 import seedu.address.model.pdf.Pdf;
 import seedu.address.model.pdf.exceptions.PdfNotFoundException;
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -16,7 +16,6 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 
-import seedu.address.logic.CommandHistory;
 import seedu.address.model.pdf.Pdf;
 import seedu.address.model.pdf.exceptions.PdfNotFoundException;
 

--- a/src/main/java/seedu/address/model/VersionedPdfBook.java
+++ b/src/main/java/seedu/address/model/VersionedPdfBook.java
@@ -41,6 +41,7 @@ public class VersionedPdfBook extends PdfBook {
         if (!canUndo()) {
             throw new NoUndoableStateException();
         }
+
         currentStatePointer--;
         resetData(pdfBookStateList.get(currentStatePointer));
     }


### PR DESCRIPTION
Undo /Redo commands are causing security issues with following commands:
- Move
- Rename
- Edit
- Delete

Related to #246 #220

Removed until further notice