### PR TITLE
(v1.4) Fix Security flaw in Encrypt

### DIFF
--- a/src/main/java/seedu/address/logic/CommandHistory.java
+++ b/src/main/java/seedu/address/logic/CommandHistory.java
@@ -24,7 +24,9 @@ public class CommandHistory {
      */
     public void add(String userInput) {
         requireNonNull(userInput);
-        userInputHistory.add(userInput);
+        if (!userInput.contains("encrypt") && !userInput.contains("decrypt")) {
+            userInputHistory.add(userInput);
+        }
     }
 
     /**


### PR DESCRIPTION
Previously: Previously, encrypt and decrypt commands could be seen when
user presses up arrow or down arrow to view last command.
Fix: Do not save encrypt or decrypt command.

Need to include this information in the UG. #214
Resolves: #240