### PR TITLE
(v1.4) Bug fix on Tag Command

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -12,5 +12,6 @@ public class Messages {
     public static final String MESSAGE_PDF_OPEN_FAIL = "This pdf file could not be accessed: %1$s";
     public static final String MESSAGE_MISSING_PREFIX = "One or more parameters has missing prefix '$1$s'";
     public static final String MESSAGE_NO_DEADLINE_IN_PDF = "The file you selected does not have an existing deadline.";
+    public static final String MESSAGE_NO_TAG_IN_PDF = "Tag does not exist!";
 
 }

--- a/src/main/java/seedu/address/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagCommand.java
@@ -79,11 +79,15 @@ public class TagCommand extends Command {
         return new Pdf(old.getName(), old.getDirectory(), old.getSize(), nTags, old.getDeadline());
     }
 
-    public static Pdf getPdfWithRemovedTag(Pdf old, Set<Tag> tags) {
+    public static Pdf getPdfWithRemovedTag(Pdf old, Set<Tag> tags) throws CommandException {
         Set<Tag> oTags = old.getTags();
         Set<Tag> nTags = new HashSet<>(oTags);
-        nTags.removeAll(tags);
-        return new Pdf(old.getName(), old.getDirectory(), old.getSize(), nTags, old.getDeadline());
+        boolean hasTag = nTags.removeAll(tags);
+        if (hasTag) {
+            return new Pdf(old.getName(), old.getDirectory(), old.getSize(), nTags, old.getDeadline());
+        } else {
+            throw new CommandException(Messages.MESSAGE_NO_TAG_IN_PDF);
+        }
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/TagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagCommandTest.java
@@ -76,7 +76,7 @@ public class TagCommandTest {
         validTags.add(new Tag(TAG_VALID_LECTURE));
 
         thrown.expect(CommandException.class);
-        TagCommand standardCommand = new TagCommand(Index.fromOneBased(20), validTags, false);
+        TagCommand standardCommand = new TagCommand(Index.fromOneBased(1), validTags, false);
         standardCommand.execute(this.model, commandHistory);
     }
 

--- a/src/test/java/seedu/address/logic/commands/TagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagCommandTest.java
@@ -71,6 +71,16 @@ public class TagCommandTest {
     }
 
     @Test
+    public void execute_nonExistingTag_throwsCommandException() throws CommandException {
+        HashSet<Tag> validTags = new HashSet<>();
+        validTags.add(new Tag(TAG_VALID_LECTURE));
+
+        thrown.expect(CommandException.class);
+        TagCommand standardCommand = new TagCommand(Index.fromOneBased(20), validTags, false);
+        standardCommand.execute(this.model, commandHistory);
+    }
+
+    @Test
     public void execute_invalidIndex_throwsInvalidException() throws CommandException {
         HashSet<Tag> validTags = new HashSet<>();
         validTags.add(new Tag(TAG_VALID_LECTURE));


### PR DESCRIPTION
Fixed no error message thrown when removing a tag that does not exist.

Resolves: #226
Resolves: #236