### PR TITLE
(v1.4) Remvoved a redundant check in Pdf.java [Can Merge, Decrease coverage by 0.01%]

### DIFF
--- a/src/main/java/seedu/address/model/pdf/Pdf.java
+++ b/src/main/java/seedu/address/model/pdf/Pdf.java
@@ -124,9 +124,8 @@ public class Pdf {
      */
     private boolean isFileEncrypted(Name name, Directory directory) {
         try (PDDocument pd = PDDocument.load(Paths.get(directory.getDirectory(), name.getFullName()).toFile())) {
-            boolean isEncrypted = pd.isEncrypted();
             pd.close();
-            return isEncrypted;
+            return false;
         } catch (IOException ioe) {
             return true;
         }


### PR DESCRIPTION
isFileEncrypted method performs a redundant check in checking if the
file is encrypted. This uses an external API that seems to be unreliable
in some cases. Removed it and streamlined the process to remove that
bug.